### PR TITLE
CcspPandMSsp process crashed trying to delete old wwan0 IPv6 route

### DIFF
--- a/source/libnet.c
+++ b/source/libnet.c
@@ -130,7 +130,8 @@ libnet_status vlan_create(const char *if_name, int vid)
 
         master_index = rtnl_link_name2i(link_cache, if_name);
         if (!master_index) {
-                CNL_LOG_ERROR("Unable to lookup %s (not found)\n", if_name);
+                CNL_LOG_ERROR("Unable to lookup interface %s (master_index=%d)\n", 
+                        if_name, master_index);
                 goto FREE_CACHE;
         }
 
@@ -143,15 +144,15 @@ libnet_status vlan_create(const char *if_name, int vid)
 
         ret = rtnl_link_vlan_set_id(link, vid);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to set vlan id %d for %s: %s (err=%d, errno=%d: %s)\n",
-                        vid, vlan_if_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to set vlan id %d for %s: %s (err=%d)\n",
+                        vid, vlan_if_name, nl_geterror(ret), ret);
                 goto FREE_VLAN;
         }
 
         ret = rtnl_link_add(sk, link, NLM_F_CREATE | NLM_F_EXCL);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to add vlan link %s: %s (err=%d, errno=%d: %s)\n",
-                        vlan_if_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to add vlan link %s: %s (err=%d)\n",
+                        vlan_if_name, nl_geterror(ret), ret);
                 goto FREE_VLAN;
         }
         err = CNL_STATUS_SUCCESS;
@@ -196,8 +197,8 @@ libnet_status vlan_delete(const char *vlan_name)
 
         int ret = rtnl_link_delete(sk, link);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to delete vlan %s: %s (err=%d, errno=%d: %s)\n",
-                        vlan_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to delete vlan %s: %s (err=%d)\n",
+                        vlan_name, nl_geterror(ret), ret);
                 goto FREE_LINK;
         }
         err = CNL_STATUS_SUCCESS;
@@ -238,16 +239,16 @@ libnet_status bridge_create(const char* bridge_name)
         }
         int ret = rtnl_link_set_type(link, "bridge");
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to set link type to bridge for %s: %s (err=%d, errno=%d: %s)\n",
-                        bridge_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to set link type to bridge for %s: %s (err=%d)\n",
+                        bridge_name, nl_geterror(ret), ret);
                 goto FREE_LINK;
         }
         rtnl_link_set_name(link, bridge_name);
 
         ret = rtnl_link_add(sk, link, NLM_F_CREATE | NLM_F_EXCL);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to create bridge %s: %s (err=%d, errno=%d: %s)\n",
-                        bridge_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to create bridge %s: %s (err=%d)\n",
+                        bridge_name, nl_geterror(ret), ret);
                 goto FREE_LINK;
         }
         err = CNL_STATUS_SUCCESS;
@@ -290,8 +291,8 @@ libnet_status bridge_delete(const char* bridge_name)
 
         int ret = rtnl_link_delete(sk, link);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to delete bridge %s: %s (err=%d, errno=%d: %s)\n",
-                        bridge_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to delete bridge %s: %s (err=%d)\n",
+                        bridge_name, nl_geterror(ret), ret);
                 goto FREE_LINK;
         }
         err = CNL_STATUS_SUCCESS;
@@ -350,8 +351,8 @@ libnet_status interface_add_to_bridge(const char* bridge_name, const char* if_na
 
         ret = rtnl_link_enslave(sk, link, ltap);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to enslave %s to bridge %s: %s (err=%d, errno=%d: %s)\n",
-                        if_name, bridge_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to enslave %s to bridge %s: %s (err=%d)\n",
+                        if_name, bridge_name, nl_geterror(ret), ret);
                 goto FREE_LINK2;
         }
         err = CNL_STATUS_SUCCESS;
@@ -406,8 +407,8 @@ libnet_status interface_remove_from_bridge (const char *if_name)
 
         ret = rtnl_link_release(sk, ltap);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to release %s from bridge: %s (err=%d, errno=%d: %s)\n",
-                        if_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to release %s from bridge: %s (err=%d)\n",
+                        if_name, nl_geterror(ret), ret);
                 goto FREE_LINK;
         }
         err = CNL_STATUS_SUCCESS;
@@ -533,8 +534,8 @@ libnet_status interface_up(char *if_name)
         rtnl_link_set_flags(change, flags);
         ret = rtnl_link_change(sk, link, change, 0);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to bring up interface %s: %s (err=%d, errno=%d: %s)\n",
-                        if_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to bring up interface %s: %s (err=%d)\n",
+                        if_name, nl_geterror(ret), ret);
                 goto FREE_LINK2;
         }
 
@@ -599,8 +600,8 @@ libnet_status interface_down(char *if_name)
 
         ret = rtnl_link_change(sk, link, change, 0);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to bring down interface %s: %s (err=%d, errno=%d: %s)\n",
-                        if_name, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to bring down interface %s: %s (err=%d)\n",
+                        if_name, nl_geterror(ret), ret);
                 goto FREE_LINK2;
         }
 
@@ -1234,13 +1235,8 @@ static void route_delete_cb(struct nl_object *obj, void *arg)
         struct nl_sock *sock = (struct nl_sock *) arg;
         libnet_status err = CNL_STATUS_SUCCESS;
 
-        if ((err = rtnl_route_delete(sock, route, 0)) < 0) {
-                char dst_str[64] = {0};
-                struct nl_addr *dst = rtnl_route_get_dst(route);
-                if (dst) nl_addr2str(dst, dst_str, sizeof(dst_str));
-                CNL_LOG_ERROR("Unable to delete route to %s: %s (err=%d, errno=%d: %s)\n",
-                        dst_str, nl_geterror(err), err, errno, strerror(errno));
-        }
+        if ((err = rtnl_route_delete(sock, route, 0)) < 0)
+                CNL_LOG_ERROR("Unable to delete route - Returned err = %d\n", err);
 }
 
 /**
@@ -1462,8 +1458,8 @@ libnet_status rule_add(char *args)
 
         int ret = rtnl_rule_set_src(rule, src);
         if (ret < 0) {
-                CNL_LOG_ERROR("Unable to set rule src (family=%d): %s (err=%d, errno=%d: %s)\n",
-                        family, nl_geterror(ret), ret, errno, strerror(errno));
+                CNL_LOG_ERROR("Unable to set rule src (family=%d): %s (err=%d)\n",
+                        family, nl_geterror(ret), ret);
                 goto FREE_RULE;
         }
 

--- a/source/libnet.c
+++ b/source/libnet.c
@@ -1000,8 +1000,9 @@ libnet_status addr_delete(char *args)
                 token = strtok(NULL, " ");
         }
 
-        if (rtnl_addr_delete(sock, addr, 0) < 0) {
-                CNL_LOG_ERROR("%s: Unable to del addr \n", args);
+        int ret = rtnl_addr_delete(sock, addr, 0);
+        if (ret < 0) {
+                CNL_LOG_ERROR("%s: Unable to del addr (error: %d)\n", args, ret);
                 goto FREE_ADDR;
         }
         err = CNL_STATUS_SUCCESS;

--- a/source/libnet.c
+++ b/source/libnet.c
@@ -934,8 +934,22 @@ libnet_status addr_delete(char *args)
         }
 
         link_cache = libnet_link_alloc_cache(sock);
+        if (link_cache == NULL) {
+                CNL_LOG_ERROR("Unable to allocate link cache\n");
+                goto FREE_SOCKET;
+        }
+
         addr_cache = libnet_addr_alloc_cache(sock);
+        if (addr_cache == NULL) {
+                CNL_LOG_ERROR("Unable to allocate addr cache\n");
+                goto FREE_LINK_CACHE;
+        }
+
         addr = libnet_addr_alloc();
+        if (addr == NULL) {
+                CNL_LOG_ERROR("Unable to allocate addr\n");
+                goto FREE_ADDR_CACHE;
+        }
 
         token = strtok(str, " ");
         while( token != NULL) {
@@ -994,8 +1008,10 @@ libnet_status addr_delete(char *args)
 
 FREE_ADDR:
         rtnl_addr_put(addr);
-        nl_cache_free(link_cache);
+FREE_ADDR_CACHE:
         nl_cache_free(addr_cache);
+FREE_LINK_CACHE:
+        nl_cache_free(link_cache);
 
 FREE_SOCKET:
         nl_socket_free(sock);
@@ -1035,7 +1051,16 @@ libnet_status route_add(char *args)
         }
 
         link_cache = libnet_link_alloc_cache(sock);
+        if (link_cache == NULL) {
+                CNL_LOG_ERROR("Unable to allocate link cache\n");
+                goto FREE_SOCKET;
+        }
+
         route = libnet_route_alloc();
+        if (route == NULL) {
+                CNL_LOG_ERROR("Unable to allocate route\n");
+                goto FREE_LINK_CACHE;
+        }
 
         token = strtok(str, " ");
         while( token != NULL) {
@@ -1151,6 +1176,7 @@ libnet_status route_add(char *args)
 
 FREE_ROUTE:
         rtnl_route_put(route);
+FREE_LINK_CACHE:
         nl_cache_free(link_cache);
 
 FREE_SOCKET:
@@ -1201,8 +1227,22 @@ libnet_status route_delete(char *args)
         }
 
         link_cache = libnet_link_alloc_cache(sock);
+        if (link_cache == NULL) {
+                CNL_LOG_ERROR("Unable to allocate link cache\n");
+                goto FREE_SOCKET;
+        }
+
         route_cache = libnet_route_alloc_cache(sock, 0);
+        if (route_cache == NULL) {
+                CNL_LOG_ERROR("Unable to allocate route cache\n");
+                goto FREE_LINK_CACHE;
+        }
+
         route = libnet_route_alloc();
+        if (route == NULL) {
+                CNL_LOG_ERROR("Unable to allocate route\n");
+                goto FREE_ROUTE_CACHE;
+        }
 
         token = strtok(str, " ");
         while (token != NULL) {
@@ -1315,9 +1355,11 @@ libnet_status route_delete(char *args)
         nl_cache_foreach_filter(route_cache, OBJ_CAST(route), route_delete_cb, (void *)sock);
         err = CNL_STATUS_SUCCESS;
 FREE_ROUTE:
-        nl_cache_free(link_cache);
-        nl_cache_free(route_cache);
         rtnl_route_put(route);
+FREE_ROUTE_CACHE:
+        nl_cache_free(route_cache);
+FREE_LINK_CACHE:
+        nl_cache_free(link_cache);
 FREE_SOCKET:
         nl_socket_free(sock);
         free(str);
@@ -1526,11 +1568,15 @@ libnet_status rule_delete(char *args)
         }
 
         rule_cache = libnet_rule_alloc_cache(sock);
-        rule = libnet_rule_alloc();
+        if (rule_cache == NULL) {
+                CNL_LOG_ERROR("Unable to allocate rule cache\n");
+                goto FREE_SOCKET;
+        }
 
+        rule = libnet_rule_alloc();
         if (rule == NULL) {
                 CNL_LOG_ERROR("Unable to allocate memory for rule\n");
-                goto FREE_SOCKET;
+                goto FREE_CACHE;
         }
 
         token = strtok(str, " ");

--- a/source/libnet.h
+++ b/source/libnet.h
@@ -38,15 +38,6 @@
 #define NEIGH_STATE_NONE         0x00
 #endif
 
-#define CNL_LOG_INFO(format, ...)     \
-                              fprintf (stderr, "%s: "format, __FUNCTION__, ##__VA_ARGS__)
-#define CNL_LOG_ERROR(format, ...)    \
-                              fprintf (stderr, "%s: "format, __FUNCTION__, ##__VA_ARGS__)
-#define CNL_LOG_NOTICE(format, ...)   \
-                              fprintf (stderr, "%s: "format, __FUNCTION__, ##__VA_ARGS__)
-#define CNL_LOG_WARNING(format, ...)  \
-                              fprintf (stderr, "%s: "format, __FUNCTION__, ##__VA_ARGS__)
-
 typedef enum {
         CNL_STATUS_SUCCESS = 0,
         CNL_STATUS_FAILURE = -1

--- a/source/libnet_util.c
+++ b/source/libnet_util.c
@@ -36,8 +36,8 @@ int libnet_connect(struct nl_sock *socket, int proto)
 
         err = nl_connect(socket, proto);
         if (err < 0) {
-                fprintf(stderr, "Failed to connect netlink socket: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to connect netlink socket (proto=%d): %s (err=%d)\n",
+                        proto, nl_geterror(err), err);
         }
 
         return err;
@@ -49,7 +49,7 @@ struct nl_sock *libnet_alloc_socket(void)
 
         socket = nl_socket_alloc();
         if (socket == NULL) {
-                fprintf(stderr, "Failed to allocate netlink socket");
+                CNL_LOG_ERROR("Failed to allocate netlink socket\n");
                 return NULL;
         }
 
@@ -62,7 +62,7 @@ int libnet_addr_parse(const char *str, int family, struct nl_addr **addr)
 
         err = nl_addr_parse(str, family, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to parse address '%s': %s (err=%d)\n",
+                CNL_LOG_ERROR("Failed to parse address '%s': %s (err=%d)\n",
                         str, nl_geterror(err), err);
                 return err;
         }
@@ -78,8 +78,8 @@ struct nl_cache *libnet_alloc_cache(struct nl_sock *socket, const char *name,
 
         err = ac(socket, &cache);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate %s cache: %s",
-                        name, nl_geterror(err));
+                CNL_LOG_ERROR("Failed to allocate %s cache: %s (err=%d)\n",
+                        name, nl_geterror(err), err);
                 return NULL;
         }
 
@@ -96,8 +96,8 @@ struct nl_cache *libnet_alloc_cache_flags(struct nl_sock *socket,
 
         err = ac(socket, &cache, flags);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate %s cache: %s",
-                        name, nl_geterror(err));
+                CNL_LOG_ERROR("Failed to allocate %s cache (flags=0x%x): %s (err=%d)\n",
+                        name, flags, nl_geterror(err), err);
                 return NULL;
         }
 
@@ -112,7 +112,7 @@ struct rtnl_link *libnet_link_alloc(void)
 
         rt_link = rtnl_link_alloc();
         if (rt_link == NULL) {
-                fprintf(stderr, "Failed to allocate link object");
+                CNL_LOG_ERROR("Failed to allocate link object\n");
                 return NULL;
         }
 
@@ -128,8 +128,8 @@ struct nl_cache *libnet_link_alloc_cache_family_flags(struct nl_sock *socket,
 
         err = rtnl_link_alloc_cache_flags(socket, family, &cache, flags);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate link cache: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to allocate link cache (family=%d, flags=0x%x): %s (err=%d)\n",
+                        family, flags, nl_geterror(err), err);
                 return NULL;
         }
 
@@ -160,7 +160,7 @@ struct rtnl_addr *libnet_addr_alloc(void)
 
         address = rtnl_addr_alloc();
         if (address == NULL) {
-                fprintf(stderr, "Failed to allocate address object");
+                CNL_LOG_ERROR("Failed to allocate address object\n");
                 return NULL;
         }
 
@@ -179,8 +179,8 @@ int libnet_addr_parse_local(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_local(address, nl_a);
         if (err < 0) {
-                fprintf(stderr, "Failed to set local address: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set local address '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
         }
 
 FREE_ADDR:
@@ -195,13 +195,13 @@ int libnet_addr_parse_dev(struct rtnl_addr *address, struct nl_cache *link_cache
         int err = 0;
 
         if (link_cache == NULL) {
-                fprintf(stderr, "link_cache is NULL");
+                CNL_LOG_ERROR("link_cache is NULL\n");
                 return EINVAL;
         }
 
         ival = rtnl_link_name2i(link_cache, args);
         if (ival <= 0) {
-                fprintf(stderr, "Link %s does not exist or invalid index", args);
+                CNL_LOG_ERROR("Link '%s' does not exist or invalid index\n", args);
                 return ENOENT;
         }
 
@@ -215,8 +215,8 @@ int libnet_addr_parse_label(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_label(address, args);
         if (err < 0) {
-                fprintf(stderr, "Failed to set address label: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set address label '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
         }
 
         return err;
@@ -234,8 +234,8 @@ int libnet_addr_parse_peer(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_peer(address, nl_a);
         if (err < 0)
-                fprintf(stderr, "Failed to set peer address: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set peer address '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
 
 FREE_ADDR:
         nl_addr_put(nl_a);
@@ -254,8 +254,8 @@ int libnet_addr_parse_broadcast(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_broadcast(address, nl_a);
         if (err < 0) {
-                fprintf(stderr, "Failed to set broadcast address: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set broadcast address '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -273,7 +273,7 @@ static uint32_t parse_lifetime(const char *args, int *err)
 
         *err = nl_str2msec(args, &msecs);
         if (*err < 0) {
-                fprintf(stderr, "Failed to parse time string '%s': %s (err=%d)\n",
+                CNL_LOG_ERROR("Failed to parse time string '%s': %s (err=%d)\n",
                         args, nl_geterror(*err), *err);
                 return 0;
         }
@@ -316,7 +316,7 @@ struct rtnl_route *libnet_route_alloc(void)
 
         rt_route = rtnl_route_alloc();
         if (rt_route == NULL) {
-                fprintf(stderr, "Failed to allocate route object");
+                CNL_LOG_ERROR("Failed to allocate route object\n");
                 return NULL;
         }
 
@@ -330,8 +330,8 @@ struct nl_cache *libnet_route_alloc_cache(struct nl_sock *socket, int flags)
 
         err = rtnl_route_alloc_cache(socket, AF_UNSPEC, flags, &cache);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate route cache: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to allocate route cache (flags=%d): %s (err=%d)\n",
+                        flags, nl_geterror(err), err);
                 return NULL;
         }
 
@@ -350,8 +350,8 @@ int libnet_route_parse_dst(struct rtnl_route *rt_route, char *args)
 
         err = rtnl_route_set_dst(rt_route, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to set destination address: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set destination address '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -372,8 +372,8 @@ int libnet_route_parse_src(struct rtnl_route *rt_route, char *args)
 
         err = rtnl_route_set_src(rt_route, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to set source address: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set source address '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -394,8 +394,8 @@ int libnet_route_parse_pref_src(struct rtnl_route *rt_route, char *args)
 
         err = rtnl_route_set_pref_src(rt_route, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to set preferred source address: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set preferred source address '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -431,23 +431,25 @@ int libnet_route_parse_metric(struct rtnl_route *route, char *options)
         while (*options != '\0') {
                 index = getsubopt(&options, metrics, &argument);
                 if (index == -1) {
-                        fprintf(stderr, "Unrecognized metric token \"%s\"\n", argument ? argument : "NULL");
+                        CNL_LOG_ERROR("Unrecognized metric token \"%s\"\n",
+                                argument ? argument : "NULL");
                         return EINVAL;
                 }
 
                 if (argument == NULL) {
-                        fprintf(stderr, "Metric \"%s\", no value provided\n", metrics[index]);
+                        CNL_LOG_ERROR("Metric \"%s\", no value provided\n", metrics[index]);
                         return EINVAL;
                 }
 
                 value = strtoul(argument, &end, 0);
                 if (end == argument) {
-                        fprintf(stderr, "Metric \"%s\", value is not numeric\n", metrics[index]);
+                        CNL_LOG_ERROR("Metric \"%s\", value is not numeric\n", metrics[index]);
                         return EINVAL;
                 }
 
                 if ((index = rtnl_route_set_metric(route, index, value)) < 0) {
-                        fprintf(stderr, "Failed to set metric \"%s\": %s\n", metrics[index], nl_geterror(index));
+                        CNL_LOG_ERROR("Failed to set metric \"%s\": %s\n",
+                                metrics[index], nl_geterror(index));
                         break;
                 }
         }
@@ -479,27 +481,26 @@ int libnet_route_parse_nexthop(struct rtnl_route *rt_route, char *subopts,
         int err_val = 0;
 
         if (!(nexthop = rtnl_route_nh_alloc())) {
-                fprintf(stderr, "Out of memory");
+                CNL_LOG_ERROR("Out of memory\n");
                 return ENOMEM;
         }
 
         while (*subopts != '\0') {
                 int ret = getsubopt(&subopts, tokens, &args);
                 if (ret == -1) {
-                        fprintf(stderr, "Unknown nexthop token %s", args);
+                        CNL_LOG_ERROR("Unknown nexthop token %s\n", args);
                         return EINVAL;
                 }
 
                 if (args == NULL) {
-                        fprintf(stderr, "Missing argument to option %s\n",
-                                tokens[ret]);
+                        CNL_LOG_ERROR("Missing argument to option %s\n", tokens[ret]);
                         return EINVAL;
                 }
 
                 switch (ret) {
                 case NEXTHOP_DEV:
                         if (!(int_val = rtnl_link_name2i(link_cache, args))) {
-                                fprintf(stderr, "Link %s does not exist", args);
+                                CNL_LOG_ERROR("Link device '%s' does not exist\n", args);
                                 return ENOENT;
                         }
 
@@ -532,9 +533,7 @@ int libnet_route_parse_nexthop(struct rtnl_route *rt_route, char *subopts,
                 case NEXTHOP_WEIGHT:
                         ulval = strtoul(args, &end_ptr, 0);
                         if (end_ptr == args) {
-                                fprintf(stderr,
-                                        "Invalid weight %s, not numeric",
-                                        args);
+                                CNL_LOG_ERROR("Invalid weight %s, not numeric\n", args);
                                 return EINVAL;
                         }
                         rtnl_route_nh_set_weight(nexthop, ulval);
@@ -557,7 +556,7 @@ int libnet_route_parse_table(struct rtnl_route *rt_route, char *args)
         if (endptr == args) {
                 table = rtnl_route_str2table(args);
                 if (table < 0) {
-                        fprintf(stderr, "Unknown table name %s", args);
+                        CNL_LOG_ERROR("Unknown table name %s\n", args);
                         return EINVAL;
                 }
         }
@@ -576,7 +575,7 @@ int libnet_route_parse_prio(struct rtnl_route *route, char *arg)
 
         lval = strtoul(arg, &end_ptr, 0);
         if (end_ptr == arg) {
-                fprintf(stderr, "Invalid priority value, not numeric");
+                CNL_LOG_ERROR("Invalid priority value, not numeric\n");
                 return -1;
         }
         rtnl_route_set_priority(route, lval);
@@ -588,7 +587,7 @@ int libnet_route_parse_scope(struct rtnl_route *route, char *arg)
         int ival;
 
         if ((ival = rtnl_str2scope(arg)) < 0) {
-                fprintf(stderr, "Unknown routing scope \"%s\": %s (err=%d)\n",
+                CNL_LOG_ERROR("Unknown routing scope \"%s\": %s (err=%d)\n",
                         arg, nl_geterror(ival), ival);
                 return -1;
         }
@@ -605,8 +604,7 @@ int libnet_route_parse_protocol(struct rtnl_route *route, char *arg)
         lval = strtoul(arg, &end_ptr, 0);
         if (end_ptr == arg) {
                 if ((proto = rtnl_route_str2proto(arg)) < 0) {
-                        fprintf(stderr, "Unknown routing protocol name \"%s\"",
-                                arg);
+                        CNL_LOG_ERROR("Unknown routing protocol name \"%s\"\n", arg);
                         return -1;
                 }
         }
@@ -623,11 +621,11 @@ int libnet_route_parse_type(struct rtnl_route *route, char *arg)
         int ival;
 
         if ((ival = nl_str2rtntype(arg)) < 0)
-                fprintf(stderr, "Unknown routing type \"%s\": %s (err=%d)\n",
+                CNL_LOG_ERROR("Unknown routing type \"%s\": %s (err=%d)\n",
                         arg, nl_geterror(ival), ival);
 
         if ((ival = rtnl_route_set_type(route, ival)) < 0)
-                fprintf(stderr, "Unable to set routing type: %s (err=%d)\n",
+                CNL_LOG_ERROR("Unable to set routing type: %s (err=%d)\n",
                         nl_geterror(ival), ival);
         return ival;
 }
@@ -640,7 +638,7 @@ struct rtnl_rule *libnet_rule_alloc(void)
 
         rt_rule = rtnl_rule_alloc();
         if (rt_rule == NULL) {
-                fprintf(stderr, "Failed to allocate rule object");
+                CNL_LOG_ERROR("Failed to allocate rule object\n");
                 return NULL;
         }
 
@@ -654,7 +652,7 @@ struct nl_cache *libnet_rule_alloc_cache(struct nl_sock *socket)
 
         err = rtnl_rule_alloc_cache(socket, AF_UNSPEC, &cache);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate routing rule cache: %s (err=%d)\n",
+                CNL_LOG_ERROR("Failed to allocate routing rule cache: %s (err=%d)\n",
                         nl_geterror(err), err);
                 return NULL;
         }
@@ -670,7 +668,7 @@ struct rtnl_neigh *libnet_neigh_alloc(void)
 
         rt_neigh = rtnl_neigh_alloc();
         if (rt_neigh == NULL)
-                fprintf(stderr, "Failed to allocate neighbour object");
+                CNL_LOG_ERROR("Failed to allocate neighbour object\n");
         return rt_neigh;
 }
 
@@ -684,8 +682,8 @@ int libnet_neigh_parse_dst(struct rtnl_neigh *rt_neigh, char *args)
                 return err;
         err = rtnl_neigh_set_dst(rt_neigh, nl_a);
         if (err < 0) {
-                fprintf(stderr, "Failed to set local address: %s (err=%d)\n",
-                        nl_geterror(err), err);
+                CNL_LOG_ERROR("Failed to set neighbour destination address '%s': %s (err=%d)\n",
+                        args, nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 FREE_ADDR:
@@ -701,7 +699,7 @@ int libnet_neigh_parse_dev(struct rtnl_neigh *rt_neigh,
 
         ival = rtnl_link_name2i(link_cache, args);
         if (ival == 0) {
-                fprintf(stderr, "%s does not exist", args);
+                CNL_LOG_ERROR("Neighbour device '%s' does not exist\n", args);
                 return err;
         }
         rtnl_neigh_set_ifindex(rt_neigh, ival);

--- a/source/libnet_util.c
+++ b/source/libnet_util.c
@@ -126,7 +126,8 @@ struct nl_cache *libnet_link_alloc_cache_family_flags(struct nl_sock *socket,
 
         err = rtnl_link_alloc_cache_flags(socket, family, &cache, flags);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate link cache");
+                fprintf(stderr, "Failed to allocate link cache: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 return NULL;
         }
 

--- a/source/libnet_util.c
+++ b/source/libnet_util.c
@@ -36,7 +36,8 @@ int libnet_connect(struct nl_sock *socket, int proto)
 
         err = nl_connect(socket, proto);
         if (err < 0) {
-                fprintf(stderr, "Failed to connect netlink socket");
+                fprintf(stderr, "Failed to connect netlink socket: %s (err=%d)\n",
+                        nl_geterror(err), err);
         }
 
         return err;
@@ -61,7 +62,8 @@ int libnet_addr_parse(const char *str, int family, struct nl_addr **addr)
 
         err = nl_addr_parse(str, family, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to parse address");
+                fprintf(stderr, "Failed to parse address '%s': %s (err=%d)\n",
+                        str, nl_geterror(err), err);
                 return err;
         }
 
@@ -177,7 +179,8 @@ int libnet_addr_parse_local(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_local(address, nl_a);
         if (err < 0) {
-                fprintf(stderr, "Failed to set local address");
+                fprintf(stderr, "Failed to set local address: %s (err=%d)\n",
+                        nl_geterror(err), err);
         }
 
 FREE_ADDR:
@@ -212,7 +215,8 @@ int libnet_addr_parse_label(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_label(address, args);
         if (err < 0) {
-                fprintf(stderr, "Failed to set address label");
+                fprintf(stderr, "Failed to set address label: %s (err=%d)\n",
+                        nl_geterror(err), err);
         }
 
         return err;
@@ -230,7 +234,8 @@ int libnet_addr_parse_peer(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_peer(address, nl_a);
         if (err < 0)
-                fprintf(stderr, "Failed to set peer address");
+                fprintf(stderr, "Failed to set peer address: %s (err=%d)\n",
+                        nl_geterror(err), err);
 
 FREE_ADDR:
         nl_addr_put(nl_a);
@@ -249,7 +254,8 @@ int libnet_addr_parse_broadcast(struct rtnl_addr *address, char *args)
 
         err = rtnl_addr_set_broadcast(address, nl_a);
         if (err < 0) {
-                fprintf(stderr, "Failed to set broadcast address");
+                fprintf(stderr, "Failed to set broadcast address: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -267,7 +273,8 @@ static uint32_t parse_lifetime(const char *args, int *err)
 
         *err = nl_str2msec(args, &msecs);
         if (*err < 0) {
-                fprintf(stderr, "Failed to parse time string");
+                fprintf(stderr, "Failed to parse time string '%s': %s (err=%d)\n",
+                        args, nl_geterror(*err), *err);
                 return 0;
         }
 
@@ -323,7 +330,8 @@ struct nl_cache *libnet_route_alloc_cache(struct nl_sock *socket, int flags)
 
         err = rtnl_route_alloc_cache(socket, AF_UNSPEC, flags, &cache);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate route cache");
+                fprintf(stderr, "Failed to allocate route cache: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 return NULL;
         }
 
@@ -342,7 +350,8 @@ int libnet_route_parse_dst(struct rtnl_route *rt_route, char *args)
 
         err = rtnl_route_set_dst(rt_route, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to set destination address");
+                fprintf(stderr, "Failed to set destination address: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -363,7 +372,8 @@ int libnet_route_parse_src(struct rtnl_route *rt_route, char *args)
 
         err = rtnl_route_set_src(rt_route, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to set source address");
+                fprintf(stderr, "Failed to set source address: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -384,7 +394,8 @@ int libnet_route_parse_pref_src(struct rtnl_route *rt_route, char *args)
 
         err = rtnl_route_set_pref_src(rt_route, addr);
         if (err < 0) {
-                fprintf(stderr, "Failed to set preferred source address");
+                fprintf(stderr, "Failed to set preferred source address: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 
@@ -577,7 +588,8 @@ int libnet_route_parse_scope(struct rtnl_route *route, char *arg)
         int ival;
 
         if ((ival = rtnl_str2scope(arg)) < 0) {
-                fprintf(stderr, "Unknown routing scope \"%s\"", arg);
+                fprintf(stderr, "Unknown routing scope \"%s\": %s (err=%d)\n",
+                        arg, nl_geterror(ival), ival);
                 return -1;
         }
         rtnl_route_set_scope(route, ival);
@@ -611,10 +623,12 @@ int libnet_route_parse_type(struct rtnl_route *route, char *arg)
         int ival;
 
         if ((ival = nl_str2rtntype(arg)) < 0)
-                fprintf(stderr, "Unknown routing type \"%s\"", arg);
+                fprintf(stderr, "Unknown routing type \"%s\": %s (err=%d)\n",
+                        arg, nl_geterror(ival), ival);
 
         if ((ival = rtnl_route_set_type(route, ival)) < 0)
-                fprintf(stderr, "Unable to set routing type: %d", ival);
+                fprintf(stderr, "Unable to set routing type: %s (err=%d)\n",
+                        nl_geterror(ival), ival);
         return ival;
 }
 
@@ -640,7 +654,8 @@ struct nl_cache *libnet_rule_alloc_cache(struct nl_sock *socket)
 
         err = rtnl_rule_alloc_cache(socket, AF_UNSPEC, &cache);
         if (err < 0) {
-                fprintf(stderr, "Failed to allocate routing rule cache");
+                fprintf(stderr, "Failed to allocate routing rule cache: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 return NULL;
         }
 
@@ -669,7 +684,8 @@ int libnet_neigh_parse_dst(struct rtnl_neigh *rt_neigh, char *args)
                 return err;
         err = rtnl_neigh_set_dst(rt_neigh, nl_a);
         if (err < 0) {
-                fprintf(stderr, "Failed to set local address");
+                fprintf(stderr, "Failed to set local address: %s (err=%d)\n",
+                        nl_geterror(err), err);
                 goto FREE_ADDR;
         }
 FREE_ADDR:

--- a/source/libnet_util.h
+++ b/source/libnet_util.h
@@ -77,6 +77,10 @@ struct nl_cache *libnet_route_alloc_cache(struct nl_sock *sk, int flags);
 
 int libnet_route_parse_dst(struct rtnl_route *route, char *arg);
 
+int libnet_route_parse_src(struct rtnl_route *route, char *arg);
+
+int libnet_route_parse_pref_src(struct rtnl_route *route, char *arg);
+
 int libnet_route_parse_metric(struct rtnl_route *route, char *subopts);
 
 int libnet_route_parse_nexthop(struct rtnl_route *route, char *subopts,

--- a/source/libnet_util.h
+++ b/source/libnet_util.h
@@ -23,6 +23,15 @@
 extern "C" {
 #endif
 
+#define CNL_LOG_INFO(format, ...)     \
+                              fprintf (stderr, "%s:%d "format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define CNL_LOG_ERROR(format, ...)    \
+                              fprintf (stderr, "%s:%d "format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define CNL_LOG_NOTICE(format, ...)   \
+                              fprintf (stderr, "%s:%d "format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define CNL_LOG_WARNING(format, ...)  \
+                              fprintf (stderr, "%s:%d "format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+
 /************** Common helpers ******************/
 
 struct nl_sock *libnet_alloc_socket(void);


### PR DESCRIPTION
[LTE-2777](https://ccp.sys.comcast.net/browse/LTE-2777): Fix CcspPandMSsp process crash

Reason for change: PAM is crashing when trying to delete the old IPv6 wwan0 address and route

Test Procedure:
` root@xle-wnc:~# first_pid="$(ps | awk '/[C]cspPandMSsp/ {print $1; exit}')" ; echo "Initial PID: ${first_pid:-not running}" ; i=1 ; while [ $i -le 10 ]; do systemctl restart RdkCellularManager.service && sleep 20 ; pid="$(ps | awk '/[C]cspPandMSsp/ {print $1; exit}')" ; echo "Run $i: PID=${pid:-not running}" ; [ -z "$first_pid" ] && first_pid="$pid" ; if [ "${pid:-}" != "${first_pid:-}" ]; then echo "PID changed! Expected ${first_pid:-none}, got ${pid:-none}" ; else echo "PID unchanged" ; fi ; i=$((i+1)) ; done`
Risks: Low
Signed-off-by:Veeraputhiran_Thangavel@comcast.com

[LTE-2777-UT.txt](https://github.com/user-attachments/files/23902436/LTE-2777-UT.txt)
