### PR TITLE
RDKCOM-5503: RDKBDEV-3337 Fix Klocwork error due to unbounded copy in interface_set_mac API in core-net-lib

### DIFF
--- a/source/libnet.c
+++ b/source/libnet.c
@@ -722,7 +722,7 @@ libnet_status interface_set_mac(const char *if_name, char *mac)
                 return CNL_STATUS_FAILURE;
         }
 
-        strcpy(if_req.ifr_name, if_name);
+        snprintf(if_req.ifr_name, sizeof(if_req.ifr_name), "%s", if_name);
         if_req.ifr_hwaddr.sa_family = ARPHRD_ETHER;
 
         if(ioctl(sock, SIOCSIFHWADDR, &if_req) < 0)


### PR DESCRIPTION
Reason for change: While executing Klocwork (static code analysis tool) on our SDK code, we observed an error due to unbounded copy from interface_set_mac API in core-net-lib.

Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>