### PR TITLE
RDKB-63061: [GitHub Coverity] Enable Coverity Scan for core-net-library using Native Build Integration

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,36 @@
+name: Build core-net-library Component in Native Environment
+
+on:
+  push:
+    branches: [ main, 'sprint/**', 'release/**', develop ]
+  pull_request:
+    branches: [ main, 'sprint/**', 'release/**', topic/RDK*, develop ]
+
+jobs:
+  build-core-net-library-on-pr:
+    name: Build core-net-library component in github rdkcentral
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: native build
+        run: |
+          # Trust the workspace
+          git config --global --add safe.directory '*'
+
+          # Pull the latest changes for the native build system
+          git submodule update --init --recursive --remote
+
+          # Build and install dependencies
+          chmod +x build_tools_workflows/cov_docker_script/setup_dependencies.sh
+          ./build_tools_workflows/cov_docker_script/setup_dependencies.sh ./cov_docker_script/component_config.json
+
+          # Build component
+          chmod +x build_tools_workflows/cov_docker_script/build_native.sh
+          ./build_tools_workflows/cov_docker_script/build_native.sh ./cov_docker_script/component_config.json "$(pwd)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "build_tools_workflows"]
+	path = build_tools_workflows
+	url = https://github.com/rdkcentral/build_tools_workflows
+	branch = develop

--- a/cov_docker_script/README.md
+++ b/cov_docker_script/README.md
@@ -1,0 +1,3 @@
+# 🔧 Coverity Native Build System for RDK-B Components
+
+The documentation and source for the RDK-B native build system has been centralized in [rdkcentral/build_tools_workflows](https://github.com/rdkcentral/build_tools_workflows/blob/develop/cov_docker_script/README.md)

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "Component Build Configuration for Coverity/Native Builds",
+  "_version": "2.0",
+  "_description": "Defines dependencies and build settings for the native component",
+  "dependencies": {
+    "_comment": "External repositories needed by this component",
+    "repos": [
+      {
+        "name": "common-library",
+        "repo": "https://github.com/rdkcentral/common-library.git",
+        "branch": "develop",
+        "header_paths": [
+	  { "source": "source/cosa/include", "destination": "$HOME/usr/include/rdkb" }
+	]
+      },
+      {
+        "name": "safec",
+        "repo": "https://github.com/rurban/safeclib.git",
+        "branch": "master",
+        "header_paths": [
+          { "source": "include", "destination": "$HOME/usr/include/rdkb" }
+        ],
+        "build": {
+          "type": "autotools"
+        }
+      }
+    ]
+  },
+  "native_component": {
+    "name": "core-net-library",
+    "include_path": "$HOME/usr/include/rdkb",
+    "lib_output_path": "$HOME/usr/local/lib/",
+    "build": {
+      "type": "autotools",
+      "configure_options_file": "cov_docker_script/configure_options.conf"
+    }
+  }
+}

--- a/cov_docker_script/configure_options.conf
+++ b/cov_docker_script/configure_options.conf
@@ -1,0 +1,29 @@
+# core-net-library Configure Options
+# This file contains autotools configure options for the core-net-library component
+# Each section can be edited independently for better maintainability
+
+# ============================================================================
+# CPPFLAGS - Preprocessor flags (includes and defines)
+# ============================================================================
+[CPPFLAGS]
+
+# Include Paths
+-I/usr/include
+-I$HOME/usr/include/rdkb
+-I$HOME/usr/include/rdkb/rtmessage
+
+# Build System & Configuration
+-DPIC
+
+# Safec dummy API
+-DSAFEC_DUMMY_API
+
+# ============================================================================
+# LDFLAGS - Linker flags
+# ============================================================================
+[LDFLAGS]
+-L$HOME/usr/local/lib/
+-Wl,-O1
+-Wl,--hash-style=gnu
+-Wl,--as-needed
+-Wl,-z,relro


### PR DESCRIPTION

Reason for change: Coverity check on native build
Test Procedure: Native build successful
Risks: Low
Priority: P1
Signed-off-by: GattuPavithran_Goud@comcast.com