### PR TITLE
Support cherry-pick label on already-merged PRs via issues:labeled trigger

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,13 +3,22 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
+  issues:
+    types: [labeled]
 
 jobs:
   cherry-pick:
-    if: github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) ||
+      (github.event_name == 'issues' &&
+       github.event.issue.pull_request.url != '' &&
+       contains(toJSON(github.event.issue.labels.*.name), 'cherry-pick to '))
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ toJSON(github.event.pull_request.labels) }}
+      raw_labels: ${{ github.event_name == 'issues' && toJSON(github.event.issue.labels) || toJSON(github.event.pull_request.labels) }}
       trigger_label: ${{ github.event.label.name }}
+      pr_number_override: ${{ github.event_name == 'issues' && github.event.issue.number || '' }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}


### PR DESCRIPTION
Follow-up to #43. Adds `issues: labeled` as a second trigger so adding a `cherry-pick to <branch>` label to an already-merged PR fires the cherry-pick engine.

Depends on rdkcentral/build_tools_workflows#72 being merged first.

Reason for change: Enable cherry-pick labels to be added at any time after merge
Test Procedure: Add label to already-merged PR #39 — workflow fires and creates backport PR
Risks: Low
Priority: P1