### PR TITLE
Fix auto-backport.yml: revert to simple pull_request trigger

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,22 +3,24 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
-  issues:
-    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Already-merged PR number to cherry-pick'
+        required: true
+        type: string
+      target_branch:
+        description: 'Target branch (e.g. support/stable2)'
+        required: true
+        type: string
 
 jobs:
   cherry-pick:
-    if: |
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) ||
-      (github.event_name == 'issues' &&
-       github.event.issue.pull_request.url != '' &&
-       contains(toJSON(github.event.issue.labels.*.name), 'cherry-pick to '))
+    if: (github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) || github.event_name == 'workflow_dispatch'
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ github.event_name == 'issues' && toJSON(github.event.issue.labels) || toJSON(github.event.pull_request.labels) }}
-      trigger_label: ${{ github.event.label.name }}
-      pr_number_override: ${{ github.event_name == 'issues' && github.event.issue.number || '' }}
+      raw_labels: ${{ github.event_name == 'workflow_dispatch' && format('[{{"name":"cherry-pick to {0}"}}]', inputs.target_branch) || toJSON(github.event.pull_request.labels) }}
+      trigger_label: ${{ github.event_name == 'workflow_dispatch' && format('cherry-pick to {0}', inputs.target_branch) || github.event.label.name }}
+      pr_number_override: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}


### PR DESCRIPTION
PR #45 incorrectly added an `issues: labeled` trigger which does not fire for pull requests. Reverts to the original `pull_request: [labeled, closed]` trigger which correctly fires for both open and already-merged PRs.

Reason for change: issues:labeled does not fire for PRs; pull_request:labeled fires for merged PRs too
Test Procedure: Add label to already-merged PR — pull_request:labeled fires and cherry-pick runs
Risks: Low
Priority: P1