### PR TITLE
Simplify auto-backport.yml: remove workflow_dispatch, match working fork

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,24 +3,13 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'Already-merged PR number to cherry-pick'
-        required: true
-        type: string
-      target_branch:
-        description: 'Target branch (e.g. support/stable2)'
-        required: true
-        type: string
 
 jobs:
   cherry-pick:
-    if: (github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ github.event_name == 'workflow_dispatch' && format('[{{"name":"cherry-pick to {0}"}}]', inputs.target_branch) || toJSON(github.event.pull_request.labels) }}
-      trigger_label: ${{ github.event_name == 'workflow_dispatch' && format('cherry-pick to {0}', inputs.target_branch) || github.event.label.name }}
-      pr_number_override: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
+      raw_labels: ${{ toJSON(github.event.pull_request.labels) }}
+      trigger_label: ${{ github.event.label.name }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}


### PR DESCRIPTION
Removes unnecessary workflow_dispatch trigger. The simple pull_request:labeled/closed pattern already works for post-merge labels (confirmed on bunnam988 fork). Matches the exact tested working pattern from the fork.

Reason for change: Simplify to tested working pattern
Test Procedure: Merge PR, add cherry-pick label → workflow fires automatically
Risks: Low
Priority: P1